### PR TITLE
Update shairport.c

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -31,11 +31,11 @@
 #include <libconfig.h>
 #include <libgen.h>
 #include <memory.h>
-#include <net/if.h>
 #include <popt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <net/if.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>


### PR DESCRIPTION
I moved "#include <net/if.h>" after #include <sys/socket.h> as the old order caused errors like "‘ifru_addr’ has incomplete type" while trying to compile under gcc-7